### PR TITLE
Harden frame parsing, backpressure, and stream safety

### DIFF
--- a/client.go
+++ b/client.go
@@ -37,7 +37,6 @@ func (c *ClientConnection) OpenStream(ctx context.Context) (*Stream, error) {
 	c.streamResponses[streamID] = ch
 	c.mu.Unlock()
 	defer func() {
-		close(ch)
 		c.mu.Lock()
 		delete(c.streamResponses, streamID)
 		c.mu.Unlock()
@@ -49,6 +48,8 @@ func (c *ClientConnection) OpenStream(ctx context.Context) (*Stream, error) {
 	}
 
 	select {
+	case <-c.ctx.Done():
+		return nil, context.Cause(c.ctx)
 	case <-ctx.Done():
 		return nil, context.Cause(ctx)
 	case response := <-ch:
@@ -69,7 +70,11 @@ func (c *ClientConnection) OpenStream(ctx context.Context) (*Stream, error) {
 func (c *ClientConnection) handle(fr frame.Frame) (err error) {
 	switch fr := fr.(type) {
 	case *frame.ConnectionResponse:
-		c.response <- fr
+		select {
+		case c.response <- fr:
+		default:
+			c.logger.Log("connection_response_unexpected")
+		}
 	case *frame.StreamResponse:
 		c.mu.RLock()
 		ch, ok := c.streamResponses[fr.StreamID]

--- a/connection.go
+++ b/connection.go
@@ -215,16 +215,22 @@ func (c *connection) receive(now, t time.Time, sequenceID uint32, frames []frame
 		c.ack.add(t, sequenceID)
 		if !c.receiveQueue.add(sequenceID) {
 			c.logger.Log("duplicate_receive", "sequenceID", sequenceID)
+			releaseFrames(frames)
 			return
 		}
 	}
 
-	for _, fr := range frames {
-		if err := c.handler(fr); err != nil {
-			return err
+	for i, fr := range frames {
+		if c.handler != nil {
+			if err := c.handler(fr); err != nil {
+				frame.PutFrame(fr)
+				releaseFrames(frames[i+1:])
+				return err
+			}
 		}
 
 		if err := c.handle(now, fr); err != nil {
+			releaseFrames(frames[i+1:])
 			return err
 		}
 	}
@@ -232,6 +238,8 @@ func (c *connection) receive(now, t time.Time, sequenceID uint32, frames []frame
 }
 
 func (c *connection) handle(now time.Time, fr frame.Frame) (err error) {
+	defer frame.PutFrame(fr)
+
 	switch fr := fr.(type) {
 	case *frame.Acknowledgement:
 		for _, r := range fr.Ranges {
@@ -264,7 +272,6 @@ func (c *connection) handle(now time.Time, fr frame.Frame) (err error) {
 	case *frame.MTUResponse:
 		c.discovery.onAck(fr.MTU)
 	}
-	frame.PutFrame(fr)
 	return
 }
 
@@ -409,11 +416,8 @@ func (c *connection) cleanup() {
 	<-c.ctx.Done()
 	c.retransmission.clear()
 	c.sendQueue.clear()
-	c.handler = nil
 	c.discovery.mtuIncrease = nil
 	clear(c.receiveQueue.queue)
-	close(c.packets)
-	close(c.notify)
 }
 
 func firstTime(idle, ack, retransmission, pacing time.Time) time.Time {

--- a/dial.go
+++ b/dial.go
@@ -36,25 +36,39 @@ func Dial(ctx context.Context, address string) (Connection, error) {
 
 	go uConn.Read(func(dgram *datagram) (err error) {
 		defer dgram.reset()
+		if !udpAddrEqual(dgram.peerAddr, addr) {
+			return nil
+		}
+
 		_, sequenceID, frames, err := frame.Unpack(dgram.b)
 		if err != nil {
 			c.logger.Log("unpack_err", "err", err.Error())
-			return err
+			return nil
 		}
 
 		select {
 		case <-c.ctx.Done():
+			releaseFrames(frames)
 			return context.Cause(c.ctx)
+		case c.packets <- &receivedPacket{sequenceID, frames, time.Now()}:
+			return
 		default:
-			c.packets <- &receivedPacket{sequenceID, frames, time.Now()}
+			releaseFrames(frames)
+			_ = c.CloseWithError(frame.ConnectionCloseInternal, "connection packet queue full")
 			return
 		}
 	})
 	select {
 	case <-ctx.Done():
+		cause := context.Cause(ctx)
+		if cause == nil {
+			cause = ctx.Err()
+		}
 		c.logger.Log("connection_request_timeout")
-		_ = c.CloseWithError(frame.ConnectionCloseInternal, fmt.Sprintf("dialer context: %v", context.Cause(ctx).Error()))
-		return nil, context.Cause(ctx)
+		_ = c.CloseWithError(frame.ConnectionCloseInternal, fmt.Sprintf("dialer context: %v", cause))
+		return nil, cause
+	case <-c.ctx.Done():
+		return nil, context.Cause(c.ctx)
 	case response := <-c.response:
 		if response.Response == frame.ConnectionResponseFailed {
 			c.logger.Log("connection_request_fail")

--- a/frame_queue.go
+++ b/frame_queue.go
@@ -2,6 +2,8 @@ package spectral
 
 import "sort"
 
+const maxFrameQueueEntries = 4096
+
 type frameEntry struct {
 	sequenceID uint32
 	payload    []byte
@@ -23,9 +25,24 @@ func (f *frameQueue) top() *frameEntry {
 	return nil
 }
 
-func (f *frameQueue) enqueue(sequenceID uint32, p []byte) {
+func (f *frameQueue) enqueue(sequenceID uint32, p []byte) bool {
+	if sequenceID < f.expected {
+		return true
+	}
+
+	for _, entry := range f.queue {
+		if entry.sequenceID == sequenceID {
+			return true
+		}
+	}
+
+	if len(f.queue) >= maxFrameQueueEntries {
+		return false
+	}
+
 	f.queue = append(f.queue, &frameEntry{sequenceID: sequenceID, payload: append([]byte(nil), p...)})
 	sort.Slice(f.queue, func(i, j int) bool { return f.queue[i].sequenceID < f.queue[j].sequenceID })
+	return true
 }
 
 func (f *frameQueue) dequeue() {

--- a/internal/congestion/rtt.go
+++ b/internal/congestion/rtt.go
@@ -30,7 +30,7 @@ func (r *RTT) Add(latestRTT, ackDelay time.Duration) {
 	}
 
 	r.latestRTT = latestRTT
-	if r.measured {
+	if !r.measured {
 		r.measured = true
 		r.minRTT = latestRTT
 		r.smoothedRTT = latestRTT

--- a/internal/frame/acknowledgement.go
+++ b/internal/frame/acknowledgement.go
@@ -3,6 +3,9 @@ package frame
 import (
 	"encoding/binary"
 	"errors"
+	"fmt"
+
+	"github.com/cooldogedev/spectral/internal/protocol"
 )
 
 type AcknowledgementRange [2]uint32
@@ -39,11 +42,18 @@ func (fr *Acknowledgement) Decode(p []byte) (int, error) {
 	fr.Delay = int64(binary.LittleEndian.Uint64(p[0:8]))
 	fr.Max = binary.LittleEndian.Uint32(p[8:12])
 	length := binary.LittleEndian.Uint32(p[12:16])
+	if length > protocol.MaxAckRanges {
+		return 0, fmt.Errorf("ack range count exceeds limit: %d", length)
+	}
 	if len(p) < 16+int(length)*8 {
 		return 0, errors.New("not enough data to decode ranges")
 	}
 
-	fr.Ranges = fr.Ranges[:length]
+	if cap(fr.Ranges) < int(length) {
+		fr.Ranges = make([]AcknowledgementRange, int(length))
+	} else {
+		fr.Ranges = fr.Ranges[:length]
+	}
 	for i := uint32(0); i < length; i++ {
 		offset := 16 + i*8
 		fr.Ranges[i][0] = binary.LittleEndian.Uint32(p[offset : offset+4])

--- a/internal/frame/mtu_request.go
+++ b/internal/frame/mtu_request.go
@@ -3,6 +3,8 @@ package frame
 import (
 	"encoding/binary"
 	"errors"
+
+	"github.com/cooldogedev/spectral/internal/protocol"
 )
 
 type MTURequest struct {
@@ -14,8 +16,15 @@ func (fr *MTURequest) ID() uint32 {
 }
 
 func (fr *MTURequest) Encode() []byte {
-	p := make([]byte, fr.MTU)
-	binary.LittleEndian.PutUint64(p[0:8], fr.MTU)
+	mtu := fr.MTU
+	if mtu < 8 {
+		mtu = 8
+	}
+	if mtu > protocol.MaxPacketSize {
+		mtu = protocol.MaxPacketSize
+	}
+	p := make([]byte, mtu)
+	binary.LittleEndian.PutUint64(p[0:8], mtu)
 	return p
 }
 
@@ -23,8 +32,17 @@ func (fr *MTURequest) Decode(p []byte) (int, error) {
 	if len(p) < 8 {
 		return 0, errors.New("not enough data to decode")
 	}
-	fr.MTU = binary.LittleEndian.Uint64(p[0:8])
-	return int(fr.MTU), nil
+
+	mtu := binary.LittleEndian.Uint64(p[0:8])
+	if mtu < 8 || mtu > protocol.MaxPacketSize {
+		return 0, errors.New("invalid mtu size")
+	}
+	if len(p) < int(mtu) {
+		return 0, errors.New("not enough data to decode mtu payload")
+	}
+
+	fr.MTU = mtu
+	return int(mtu), nil
 }
 
 func (fr *MTURequest) Reset() {}

--- a/internal/frame/mtu_request_test.go
+++ b/internal/frame/mtu_request_test.go
@@ -1,0 +1,57 @@
+package frame
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/cooldogedev/spectral/internal/protocol"
+)
+
+func TestMTURequestDecodeConsumesEncodedSize(t *testing.T) {
+	encoded := (&MTURequest{MTU: 1200}).Encode()
+
+	var fr MTURequest
+	n, err := fr.Decode(encoded)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if n != 1200 {
+		t.Fatalf("expected decoded size 1200, got %d", n)
+	}
+	if fr.MTU != 1200 {
+		t.Fatalf("expected decoded mtu 1200, got %d", fr.MTU)
+	}
+}
+
+func TestMTURequestEncodeClampsToProtocolMax(t *testing.T) {
+	encoded := (&MTURequest{MTU: protocol.MaxPacketSize + 100}).Encode()
+	if len(encoded) != int(protocol.MaxPacketSize) {
+		t.Fatalf("expected encoded length %d, got %d", protocol.MaxPacketSize, len(encoded))
+	}
+	if mtu := binary.LittleEndian.Uint64(encoded[:8]); mtu != protocol.MaxPacketSize {
+		t.Fatalf("expected encoded mtu %d, got %d", protocol.MaxPacketSize, mtu)
+	}
+
+	var fr MTURequest
+	n, err := fr.Decode(encoded)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if n != int(protocol.MaxPacketSize) {
+		t.Fatalf("expected decoded size %d, got %d", protocol.MaxPacketSize, n)
+	}
+}
+
+func TestMTURequestDecodeRejectsInvalidSizes(t *testing.T) {
+	tooSmall := make([]byte, 8)
+	binary.LittleEndian.PutUint64(tooSmall, 7)
+	if _, err := (&MTURequest{}).Decode(tooSmall); err == nil {
+		t.Fatal("expected error for mtu below minimum")
+	}
+
+	insufficient := make([]byte, 8)
+	binary.LittleEndian.PutUint64(insufficient, 1200)
+	if _, err := (&MTURequest{}).Decode(insufficient); err == nil {
+		t.Fatal("expected error for insufficient mtu payload bytes")
+	}
+}

--- a/internal/frame/pack.go
+++ b/internal/frame/pack.go
@@ -8,6 +8,8 @@ import (
 	"github.com/cooldogedev/spectral/internal/protocol"
 )
 
+const maxFramesPerPacket = 256
+
 func PackSingle(fr Frame) []byte {
 	id := make([]byte, 4)
 	binary.LittleEndian.PutUint32(id, fr.ID())
@@ -33,19 +35,43 @@ func Unpack(p []byte) (connectionID protocol.ConnectionID, sequenceID uint32, fr
 	sequenceID = binary.LittleEndian.Uint32(p[12:16])
 	offset := 16
 	for length > offset {
+		if length-offset < 4 {
+			releaseFrameSlice(frames)
+			return 0, 0, nil, errors.New("incomplete frame header")
+		}
+
+		if len(frames) >= maxFramesPerPacket {
+			releaseFrameSlice(frames)
+			return 0, 0, nil, errors.New("too many frames in packet")
+		}
+
 		frameID = binary.LittleEndian.Uint32(p[offset : offset+4])
 		offset += 4
 		fr, err := getFrame(frameID)
 		if err != nil {
+			releaseFrameSlice(frames)
 			return 0, 0, nil, err
 		}
 
 		n, err := fr.Decode(p[offset:])
 		if err != nil {
+			PutFrame(fr)
+			releaseFrameSlice(frames)
 			return 0, 0, nil, fmt.Errorf("error while decoding frame %v: %v", frameID, err)
+		}
+		if n < 0 || n > length-offset {
+			PutFrame(fr)
+			releaseFrameSlice(frames)
+			return 0, 0, nil, errors.New("invalid frame payload length")
 		}
 		frames = append(frames, fr)
 		offset += n
 	}
 	return
+}
+
+func releaseFrameSlice(frames []Frame) {
+	for _, fr := range frames {
+		PutFrame(fr)
+	}
 }

--- a/internal/log/logger.go
+++ b/internal/log/logger.go
@@ -28,6 +28,8 @@ type FileLogger struct {
 	mu          sync.Mutex
 }
 
+const maxBufferedLogs = 256
+
 func (f *FileLogger) SetConnectionID(connectionID protocol.ConnectionID) {
 	f.mu.Lock()
 	b := make([]byte, 20)
@@ -48,7 +50,11 @@ func (f *FileLogger) SetConnectionID(connectionID protocol.ConnectionID) {
 func (f *FileLogger) Log(event string, params ...any) {
 	var pairs []string
 	for i := 0; i < len(params); i += 2 {
-		pairs = append(pairs, fmt.Sprintf("%v=%v", params[i], params[i+1]))
+		if i+1 < len(params) {
+			pairs = append(pairs, fmt.Sprintf("%v=%v", params[i], params[i+1]))
+		} else {
+			pairs = append(pairs, fmt.Sprintf("%v=%v", params[i], "<missing>"))
+		}
 	}
 
 	log := fmt.Sprintf("timestamp=%s event=%s %s\n", time.Now().Format(time.RFC3339), event, strings.Join(pairs, " "))
@@ -56,6 +62,10 @@ func (f *FileLogger) Log(event string, params ...any) {
 	if f.writer != nil {
 		_, _ = f.writer.WriteString(log)
 	} else {
+		if len(f.buffered) >= maxBufferedLogs {
+			copy(f.buffered, f.buffered[1:])
+			f.buffered = f.buffered[:len(f.buffered)-1]
+		}
 		f.buffered = append(f.buffered, log)
 	}
 	f.mu.Unlock()

--- a/listener.go
+++ b/listener.go
@@ -15,7 +15,7 @@ import (
 type Listener struct {
 	conn                *udpConn
 	connections         map[protocol.ConnectionID]*ServerConnection
-	connectionsMu       sync.Mutex
+	connectionsMu       sync.RWMutex
 	connectionID        protocol.ConnectionID
 	incomingConnections chan *ServerConnection
 	ctx                 context.Context
@@ -37,33 +37,59 @@ func newListener(conn *udpConn) *Listener {
 			return nil
 		}
 
+		var (
+			c             *ServerConnection
+			newConnection bool
+		)
 		listener.connectionsMu.Lock()
-		defer listener.connectionsMu.Unlock()
 		c, ok := listener.connections[connectionID]
+		if ok && !udpAddrEqual(c.peerAddr, dgram.peerAddr) {
+			listener.connectionsMu.Unlock()
+			releaseFrames(frames)
+			return nil
+		}
+
 		if !ok && slices.ContainsFunc(frames, func(fr frame.Frame) bool { return fr.ID() == frame.IDConnectionRequest }) {
-			c = newServerConnection(conn, dgram.peerAddr, listener.connectionID, listener.ctx)
+			assignedID := listener.connectionID
+			c = newServerConnection(conn, dgram.peerAddr, assignedID, listener.ctx)
 			c.logger.Log("connection_accepted", "addr", dgram.peerAddr.String())
-			listener.connections[listener.connectionID] = c
+			listener.connections[assignedID] = c
 			listener.connectionID++
-			listener.incomingConnections <- c
+			newConnection = true
 			go func() {
 				<-c.ctx.Done()
 				listener.connectionsMu.Lock()
-				delete(listener.connections, protocol.ConnectionID(c.connectionID.Load()))
+				delete(listener.connections, assignedID)
 				listener.connectionsMu.Unlock()
 			}()
 		}
+		listener.connectionsMu.Unlock()
 
 		if c == nil {
+			releaseFrames(frames)
 			return
+		}
+
+		if newConnection {
+			select {
+			case listener.incomingConnections <- c:
+			default:
+				releaseFrames(frames)
+				_ = c.CloseWithError(frame.ConnectionCloseInternal, "connection accept queue full")
+				return nil
+			}
 		}
 
 		select {
 		case <-listener.ctx.Done():
+			releaseFrames(frames)
 			return context.Cause(listener.ctx)
 		case <-c.ctx.Done():
+			releaseFrames(frames)
+		case c.packets <- &receivedPacket{sequenceID, frames, time.Now()}:
 		default:
-			c.packets <- &receivedPacket{sequenceID, frames, time.Now()}
+			releaseFrames(frames)
+			_ = c.CloseWithError(frame.ConnectionCloseInternal, "connection packet queue full")
 		}
 		return
 	})
@@ -83,6 +109,7 @@ func Listen(address string) (*Listener, error) {
 
 	c, err := newUDPConn(conn, true)
 	if err != nil {
+		_ = conn.Close()
 		return nil, err
 	}
 	return newListener(c), nil
@@ -101,12 +128,32 @@ func (l *Listener) Accept(ctx context.Context) (Connection, error) {
 
 func (l *Listener) Close() (err error) {
 	l.once.Do(func() {
+		l.connectionsMu.Lock()
+		conns := make([]*ServerConnection, 0, len(l.connections))
 		for i, conn := range l.connections {
-			_ = conn.CloseWithError(frame.ConnectionCloseGraceful, "closed listener")
+			conns = append(conns, conn)
 			delete(l.connections, i)
 		}
+		l.connectionsMu.Unlock()
+
+		for _, conn := range conns {
+			_ = conn.CloseWithError(frame.ConnectionCloseGraceful, "closed listener")
+		}
 		l.cancelFunc()
-		_ = l.conn.Close()
+		_ = l.conn.closeListener()
 	})
 	return
+}
+
+func udpAddrEqual(a, b *net.UDPAddr) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.Port == b.Port && a.Zone == b.Zone && a.IP.Equal(b.IP)
+}
+
+func releaseFrames(frames []frame.Frame) {
+	for _, fr := range frames {
+		frame.PutFrame(fr)
+	}
 }

--- a/receive_queue.go
+++ b/receive_queue.go
@@ -1,5 +1,7 @@
 package spectral
 
+const maxReceiveQueueEntries = 8192
+
 type receiveQueue struct {
 	expected uint32
 	queue    map[uint32]bool
@@ -16,6 +18,17 @@ func (r *receiveQueue) add(sequenceID uint32) bool {
 	if r.exists(sequenceID) {
 		return false
 	}
+
+	if sequenceID > r.expected+maxReceiveQueueEntries {
+		return false
+	}
+
+	// Always admit the next expected sequence ID, even when the queue is full,
+	// so merge() can progress and free queued entries.
+	if len(r.queue) >= maxReceiveQueueEntries && sequenceID != r.expected {
+		return false
+	}
+
 	r.queue[sequenceID] = true
 	r.merge()
 	return true

--- a/receive_queue_test.go
+++ b/receive_queue_test.go
@@ -1,0 +1,29 @@
+package spectral
+
+import "testing"
+
+func TestReceiveQueueAllowsExpectedWhenFull(t *testing.T) {
+	q := newReceiveQueue()
+
+	for sequenceID := uint32(2); sequenceID <= maxReceiveQueueEntries+1; sequenceID++ {
+		if !q.add(sequenceID) {
+			t.Fatalf("expected sequence %d to be queued", sequenceID)
+		}
+	}
+
+	if len(q.queue) != maxReceiveQueueEntries {
+		t.Fatalf("expected queue length %d, got %d", maxReceiveQueueEntries, len(q.queue))
+	}
+
+	if !q.add(1) {
+		t.Fatal("expected missing sequence to be admitted when queue is full")
+	}
+
+	if want, got := uint32(maxReceiveQueueEntries+2), q.expected; got != want {
+		t.Fatalf("expected next sequence %d, got %d", want, got)
+	}
+
+	if len(q.queue) != 0 {
+		t.Fatalf("expected queue to be drained, got %d entries", len(q.queue))
+	}
+}

--- a/send_queue.go
+++ b/send_queue.go
@@ -6,9 +6,12 @@ import (
 	"github.com/cooldogedev/spectral/internal/protocol"
 )
 
+const maxSendQueueBytes = 32 * 1024 * 1024
+
 type sendQueue struct {
 	queue          [][]byte
 	pk             []byte
+	queuedBytes    uint64
 	maxSegmentSize uint64
 	mu             sync.RWMutex
 }
@@ -38,10 +41,17 @@ func (s *sendQueue) setMSS(mss uint64) {
 	s.mu.Unlock()
 }
 
-func (s *sendQueue) add(p []byte) {
+func (s *sendQueue) add(p []byte) bool {
 	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.queuedBytes+uint64(len(p)) > maxSendQueueBytes {
+		return false
+	}
+
 	s.queue = append(s.queue, p)
-	s.mu.Unlock()
+	s.queuedBytes += uint64(len(p))
+	return true
 }
 
 func (s *sendQueue) pack(window uint64) []byte {
@@ -59,6 +69,7 @@ func (s *sendQueue) pack(window uint64) []byte {
 		}
 		s.queue[0] = nil
 		s.queue = s.queue[1:]
+		s.queuedBytes -= uint64(len(entry))
 		s.pk = append(s.pk, entry...)
 	}
 	return s.pk
@@ -77,6 +88,7 @@ func (s *sendQueue) clear() {
 	}
 	s.queue = s.queue[:0]
 	s.queue = nil
+	s.queuedBytes = 0
 	s.pk = s.pk[:0]
 	s.pk = nil
 	s.mu.Unlock()

--- a/server.go
+++ b/server.go
@@ -26,6 +26,8 @@ func newServerConnection(conn *udpConn, peerAddr *net.UDPAddr, connectionID prot
 
 func (c *ServerConnection) AcceptStream(ctx context.Context) (*Stream, error) {
 	select {
+	case <-c.ctx.Done():
+		return nil, context.Cause(c.ctx)
 	case <-ctx.Done():
 		return nil, context.Cause(ctx)
 	case request := <-c.streamRequests:
@@ -50,7 +52,11 @@ func (c *ServerConnection) handle(fr frame.Frame) (err error) {
 			return err
 		}
 	case *frame.StreamRequest:
-		c.streamRequests <- fr
+		select {
+		case c.streamRequests <- fr:
+		default:
+			_ = c.writeControl(&frame.StreamResponse{StreamID: fr.StreamID, Response: frame.StreamResponseFailed}, true)
+		}
 	}
 	return
 }

--- a/stream.go
+++ b/stream.go
@@ -15,6 +15,8 @@ import (
 
 var streamDataPool = sync.Pool{New: func() any { return &frame.StreamData{} }}
 
+const streamBufferSize = 1024 * 1024
+
 type Stream struct {
 	ctx        context.Context
 	cancelFunc context.CancelCauseFunc
@@ -27,6 +29,7 @@ type Stream struct {
 	available  chan struct{}
 	sequenceID atomic.Uint32
 	logger     log.Logger
+	writeMu    sync.Mutex
 	mu         sync.Mutex
 	once       sync.Once
 }
@@ -41,44 +44,71 @@ func newStream(streamID protocol.StreamID, parentCtx context.Context, sendQueue 
 		closer:     closer,
 		sendQueue:  sendQueue,
 		frame:      newFrameQueue(),
-		buffer:     internal.NewRingBuffer[byte](1024 * 1024),
+		buffer:     internal.NewRingBuffer[byte](streamBufferSize),
 		available:  make(chan struct{}, 1),
 		logger:     logger,
 	}
 }
 
 func (s *Stream) Read(p []byte) (int, error) {
-	if n := s.read(p); n > 0 {
-		return n, nil
-	}
+	for {
+		if n := s.read(p); n > 0 {
+			return n, nil
+		}
 
-	select {
-	case <-s.ctx.Done():
-		return 0, context.Cause(s.ctx)
-	case <-s.available:
-		return s.read(p), nil
+		select {
+		case <-s.ctx.Done():
+			return 0, context.Cause(s.ctx)
+		case <-s.available:
+		}
 	}
 }
 
+// Write may return a partial write with an error when the connection send queue is full.
 func (s *Stream) Write(p []byte) (int, error) {
 	select {
 	case <-s.ctx.Done():
 		return 0, context.Cause(s.ctx)
 	default:
 	}
+	if len(p) == 0 {
+		return 0, nil
+	}
 
 	mss := int(s.sendQueue.mss()) - 20
+	if mss <= 0 {
+		return 0, errors.New("invalid maximum segment size")
+	}
+
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	nextSequence := s.sequenceID.Load()
+	written := 0
 	fr := streamDataPool.Get().(*frame.StreamData)
 	fr.StreamID = s.streamID
 	for payload := range slices.Chunk(p, mss) {
-		fr.SequenceID = s.sequenceID.Add(1) - 1
+		fr.SequenceID = nextSequence
 		fr.Payload = payload
-		s.sendQueue.add(frame.PackSingle(fr))
+		if !s.sendQueue.add(frame.PackSingle(fr)) {
+			fr.Payload = fr.Payload[:0]
+			streamDataPool.Put(fr)
+			if written == 0 {
+				return 0, errors.New("send queue full")
+			}
+			s.wake()
+			return written, errors.New("send queue full")
+		}
+		nextSequence++
+		s.sequenceID.Store(nextSequence)
+		written += len(payload)
 	}
 	fr.Payload = fr.Payload[:0]
 	streamDataPool.Put(fr)
-	s.wake()
-	return len(p), nil
+	if written > 0 {
+		s.wake()
+	}
+	return written, nil
 }
 
 func (s *Stream) Context() context.Context {
@@ -114,16 +144,24 @@ func (s *Stream) receive(sequenceID uint32, p []byte) {
 		return
 	default:
 	}
+	if len(p) > streamBufferSize {
+		_ = s.internalClose("stream payload exceeds buffer")
+		return
+	}
 
+	overflow := false
 	s.mu.Lock()
 	if s.frame.expected == sequenceID && s.buffer.Free() >= len(p) {
 		s.frame.expected++
 		_, _ = s.buffer.Write(p)
 	} else {
-		s.frame.enqueue(sequenceID, p)
+		overflow = !s.frame.enqueue(sequenceID, p)
 	}
 	s.processFrames()
 	s.mu.Unlock()
+	if overflow {
+		_ = s.internalClose("stream frame queue full")
+	}
 }
 
 func (s *Stream) processFrames() {

--- a/stream_test.go
+++ b/stream_test.go
@@ -1,0 +1,31 @@
+package spectral
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cooldogedev/spectral/internal/log"
+)
+
+func TestStreamWriteDoesNotSkipSequenceOnQueueFull(t *testing.T) {
+	sendQueue := newSendQueue()
+	sendQueue.setMSS(25) // payload chunk size becomes 5 bytes.
+
+	padding := make([]byte, maxSendQueueBytes-25)
+	if !sendQueue.add(padding) {
+		t.Fatal("failed to prefill send queue")
+	}
+
+	stream := newStream(1, context.Background(), sendQueue, func() {}, func() {}, log.NopLogger{})
+	written, err := stream.Write(make([]byte, 10)) // 2 chunks, second should fail.
+	if err == nil {
+		t.Fatal("expected send queue full error")
+	}
+	if written != 5 {
+		t.Fatalf("expected partial write of 5 bytes, got %d", written)
+	}
+
+	if got := stream.sequenceID.Load(); got != 1 {
+		t.Fatalf("expected sequence ID to advance by successful chunks only, got %d", got)
+	}
+}

--- a/udp.go
+++ b/udp.go
@@ -69,3 +69,7 @@ func (c *udpConn) Close() error {
 	}
 	return c.conn.Close()
 }
+
+func (c *udpConn) closeListener() error {
+	return c.conn.Close()
+}


### PR DESCRIPTION
## Summary
- Harden frame unpacking with strict bounds checks, frame-count limits, and decode-length validation to prevent malformed-packet panics.
- Fix ACK and MTU frame decoding to enforce protocol limits and consume correct frame lengths.
- Add robust frame pool cleanup on all drop/error paths (including parser/dispatch/drop branches) to avoid pooled-frame leaks under duplicate/flood conditions.
- Enforce sender address matching for active connections and add listener backpressure handling for accept/packet queues.
- Improve stream and queue correctness under load: no sequence gaps on enqueue failure, expected-packet admission when receive queue is full, and bounded send/receive/frame queues.
- Fix RTT initialization by correctly handling the first measured sample (`!r.measured`) so congestion timing starts from real latency.
- Improve lifecycle safety by avoiding shared-channel close races, honoring connection cancellation in stream open/accept flows, and adding explicit listener socket close handling.
- Harden logging behavior by handling odd key/value argument counts safely and bounding pre-open buffered logs.
- Add regression tests for stream sequencing, receive queue recovery, and MTU request decoding.

## Validation
- `go test github.com/cooldogedev/spectral github.com/cooldogedev/spectral/internal github.com/cooldogedev/spectral/internal/congestion github.com/cooldogedev/spectral/internal/frame github.com/cooldogedev/spectral/internal/log github.com/cooldogedev/spectral/internal/protocol`
- `go vet github.com/cooldogedev/spectral github.com/cooldogedev/spectral/internal github.com/cooldogedev/spectral/internal/congestion github.com/cooldogedev/spectral/internal/frame github.com/cooldogedev/spectral/internal/log github.com/cooldogedev/spectral/internal/protocol`
- `go test -race github.com/cooldogedev/spectral github.com/cooldogedev/spectral/internal/frame`